### PR TITLE
support connection pooling for the tcp client

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ You can read plc register bellow codes.
 ```go
 	client, _ := mcp.New3EClient(opts.Host, opts.Port, mcp.NewLocalStation())
 	read, _ := client.Read("D", 100, 3)
+	defer client.Close()
 	registerBinary, _ := mcp.NewParser().Do(read)
 
 	fmt.Println(string(registerBinary.Payload))


### PR DESCRIPTION
- [x] コネクションプーリングのサポート

初回接続時にコネクションが存在するか確認して、存在しない場合はコネクションを確立します。コネクションがすでに存在する場合はそのコネクションを使いまわします。

- [x] コネクションのタイムアウトをサポート
  - [x] `Timeout` に正の値が設定されている場合のみ