### PR TITLE
fix: EncodeHex

### DIFF
--- a/mcp/code.go
+++ b/mcp/code.go
@@ -1,9 +1,8 @@
 package mcp
 
 import (
-	"bytes"
 	"encoding/binary"
-	"encoding/hex"
+	"strconv"
 )
 
 // PLC Data communication code.
@@ -25,12 +24,12 @@ func (c Code) EncodeHex(s string) ([]byte, error) {
 		return []byte(s), nil
 	}
 
-	decode, err := hex.DecodeString(s)
+	hexCode, err := strconv.ParseUint(s, 16, 16)
 	if err != nil {
 		return nil, err
 	}
 
-	buff := new(bytes.Buffer)
-	_ = binary.Write(buff, binary.LittleEndian, decode)
-	return buff.Bytes(), nil
+	buff := make([]byte, 2)
+	binary.LittleEndian.PutUint16(buff, uint16(hexCode))
+	return buff, nil
 }


### PR DESCRIPTION
16進数文字列をバイト列に変換する前に、明示的に数値に変換してからLittleEndianで変換するように修正しました。

`[]byte` の値を `binary.Write` の引数として入力しても `[]byte` 型は `[]uint8` と同値ですのでエイディアンの変換ができません。

```go
		case []uint8:
			bs = v // TODO(josharian): avoid allocating bs in this case?
```

https://github.com/golang/go/blob/069f9d96d179becc61231d566c9a75f1ec26e991/src/encoding/binary/binary.go#L308-L309