### PR TITLE
implement bit read command

### DIFF
--- a/mcp/client.go
+++ b/mcp/client.go
@@ -78,13 +78,46 @@ func (c *client3E) HealthCheck() error {
 	return nil
 }
 
-// Read is send read command to remote plc by mc protocol
+// Read is send read as word command to remote plc by mc protocol
 // deviceName is device code name like 'D' register.
 // offset is device offset addr.
 // numPoints is number of read device points.
 func (c *client3E) Read(deviceName string, offset, numPoints int64) ([]byte, error) {
 	requestStr := c.stn.BuildReadRequest(deviceName, offset, numPoints)
 
+	// TODO binary protocol
+	payload, err := hex.DecodeString(requestStr)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := net.DialTCP("tcp", nil, c.tcpAddr)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	// Send message
+	if _, err = conn.Write(payload); err != nil {
+		return nil, err
+	}
+
+	// Receive message
+	readBuff := make([]byte, 22+2*numPoints) // 22 is response header size. [sub header + network num + unit i/o num + unit station num + response length + response code]
+	readLen, err := conn.Read(readBuff)
+	if err != nil {
+		return nil, err
+	}
+
+	return readBuff[:readLen], nil
+}
+
+// BitRead is send read as bit command to remote plc by mc protocol
+// deviceName is device code name like 'D' register.
+// offset is device offset addr.
+// numPoints is number of read device points.
+func (c *client3E) BitRead(deviceName string, offset, numPoints int64) ([]byte, error) {
+	requestStr := c.stn.BuildBitReadRequest(deviceName, offset, numPoints)
 	// TODO binary protocol
 	payload, err := hex.DecodeString(requestStr)
 	if err != nil {

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -9,6 +9,7 @@ import (
 
 type Client interface {
 	Read(deviceName string, offset, numPoints int64) ([]byte, error)
+	BitRead(deviceName string, offset, numPoints int64) ([]byte, error)
 	Write(deviceName string, offset, numPoints int64, writeData []byte) ([]byte, error)
 	HealthCheck() error
 }
@@ -116,6 +117,7 @@ func (c *client3E) Read(deviceName string, offset, numPoints int64) ([]byte, err
 // deviceName is device code name like 'D' register.
 // offset is device offset addr.
 // numPoints is number of read device points.
+// results of payload of BitRead will return []byte contains 0, 1, 16 or 17(hex encoded 00, 01, 10, 11)
 func (c *client3E) BitRead(deviceName string, offset, numPoints int64) ([]byte, error) {
 	requestStr := c.stn.BuildBitReadRequest(deviceName, offset, numPoints)
 	// TODO binary protocol

--- a/mcp/client_test.go
+++ b/mcp/client_test.go
@@ -80,32 +80,45 @@ func TestClient3E_BitRead(t *testing.T) {
 	}
 
 	// 1 device
-	resp1, err := client.BitRead("D", 100, 1)
+	resp1, err := client.BitRead("B", 0, 1)
 	if err != nil {
 		t.Fatalf("unexpected mcp read err: %v", err)
 	}
 
-	if len(resp1) != 13 {
-		t.Fatalf("expected %v but actual is %v", 13, len(resp1))
+	if len(resp1) != 12 {
+		t.Fatalf("expected %v but actual is %v", 12, len(resp1))
 	}
-	if hex.EncodeToString(resp1) != strings.ReplaceAll("d000 00 ff ff03 0003 0000 0000 00", " ", "") {
-		t.Fatalf("expected %v but actual is %v", "d00000ffff0300030000000000", hex.EncodeToString(resp1))
+	if hex.EncodeToString(resp1) != strings.ReplaceAll("d000 00 ff ff03 0003 0000 0000", " ", "") {
+		t.Fatalf("expected %v but actual is %v", "d00000ffff03000300000000", hex.EncodeToString(resp1))
 	}
 
 	// 3 device
-	resp2, err := client.BitRead("D", 100, 5)
+	resp2, err := client.BitRead("B", 0, 5)
 	if err != nil {
 		t.Fatalf("unexpected mcp read err: %v", err)
 	}
 
-	if len(resp2) != 17 {
-		t.Fatalf("expected %v but actual is %v", 17, len(resp2))
+	if len(resp2) != 14 {
+		t.Fatalf("expected %v but actual is %v", 14, len(resp2))
 	}
 
-	if hex.EncodeToString(resp2) != strings.ReplaceAll("d000 00 ff ff03 0007 0000 0000 0000000000", " ", "") {
-		t.Fatalf("expected %v but actual is %v", "d00000ffff03000c000000000000000000", hex.EncodeToString(resp2))
+	if hex.EncodeToString(resp2) != strings.ReplaceAll("d000 00 ff ff03 0005 0000 0000 0000", " ", "") {
+		t.Fatalf("expected %v but actual is %v", "d00000ffff030005000000000000", hex.EncodeToString(resp2))
 	}
 
+	// numpoints 5 and 6 will return same responce length
+	resp3, err := client.BitRead("B", 0, 6)
+	if err != nil {
+		t.Fatalf("unexpected mcp read err: %v", err)
+	}
+
+	if len(resp2) != 14 {
+		t.Fatalf("expected %v but actual is %v", 14, len(resp3))
+	}
+
+	if hex.EncodeToString(resp2) != strings.ReplaceAll("d000 00 ff ff03 0005 0000 0000 0000", " ", "") {
+		t.Fatalf("expected %v but actual is %v", "d00000ffff030005000000000000", hex.EncodeToString(resp3))
+	}
 }
 
 func TestClient3E_Write(t *testing.T) {

--- a/mcp/client_test.go
+++ b/mcp/client_test.go
@@ -65,6 +65,49 @@ func TestClient3E_Read(t *testing.T) {
 
 }
 
+func TestClient3E_BitRead(t *testing.T) {
+	// running only when there is and plc that can be accepted mc protocol
+	if testPLCHost == "" {
+		t.Skip("environment variable PLC_TEST_HOST is not set")
+	}
+	if testPLCPort == 0 {
+		t.Skip("environment variable PLC_TEST_PORT is not set")
+	}
+
+	client, err := New3EClient(testPLCHost, testPLCPort, NewLocalStation())
+	if err != nil {
+		t.Fatalf("PLC does not exists? %v", err)
+	}
+
+	// 1 device
+	resp1, err := client.BitRead("D", 100, 1)
+	if err != nil {
+		t.Fatalf("unexpected mcp read err: %v", err)
+	}
+
+	if len(resp1) != 13 {
+		t.Fatalf("expected %v but actual is %v", 13, len(resp1))
+	}
+	if hex.EncodeToString(resp1) != strings.ReplaceAll("d000 00 ff ff03 0003 0000 0000 00", " ", "") {
+		t.Fatalf("expected %v but actual is %v", "d00000ffff0300030000000000", hex.EncodeToString(resp1))
+	}
+
+	// 3 device
+	resp2, err := client.BitRead("D", 100, 5)
+	if err != nil {
+		t.Fatalf("unexpected mcp read err: %v", err)
+	}
+
+	if len(resp2) != 17 {
+		t.Fatalf("expected %v but actual is %v", 17, len(resp2))
+	}
+
+	if hex.EncodeToString(resp2) != strings.ReplaceAll("d000 00 ff ff03 0007 0000 0000 0000000000", " ", "") {
+		t.Fatalf("expected %v but actual is %v", "d00000ffff03000c000000000000000000", hex.EncodeToString(resp2))
+	}
+
+}
+
 func TestClient3E_Write(t *testing.T) {
 	// running only when there is and plc that can be accepted mc protocol
 	if testPLCHost == "" {

--- a/mcp/station.go
+++ b/mcp/station.go
@@ -12,8 +12,9 @@ const (
 	HEALTH_CHECK_COMMAND    = "1906" // binary mode expression. if ascii mode then 0619
 	HEALTH_CHECK_SUBCOMMAND = "0000"
 
-	READ_COMMAND     = "0104" // binary mode expression. if ascii mode then 0401
-	READ_SUB_COMMAND = "0000"
+	READ_COMMAND         = "0104" // binary mode expression. if ascii mode then 0401
+	READ_SUB_COMMAND     = "0000"
+	BIT_READ_SUB_COMMAND = "0001"
 
 	WRITE_COMMAND     = "0114" // binary mode expression. if ascii mode then 1401
 	WRITE_SUB_COMMAND = "0000"
@@ -88,7 +89,7 @@ func (h *station) BuildHealthCheckRequest() string {
 		requestStr
 }
 
-// BuildReadRequest represents MCP read command.
+// BuildReadRequest represents MCP read as word command.
 // deviceName is device code name like 'D' register.
 // offset is device offset addr.
 // numPoints is number of read device points.
@@ -123,6 +124,46 @@ func (h *station) BuildReadRequest(deviceName string, offset, numPoints int64) s
 		MONITORING_TIMER +
 		READ_COMMAND +
 		READ_SUB_COMMAND +
+		offsetHex +
+		deviceCode +
+		points
+}
+
+// BuildReadRequest represents MCP read as bit command.
+// deviceName is device code name like 'D' register.
+// offset is device offset addr.
+// numPoints is number of read device points.
+func (h *station) BuildBitReadRequest(deviceName string, offset, numPoints int64) string {
+
+	// get device symbol hex layout
+	deviceCode := deviceCodes[deviceName]
+
+	// offset convert to little endian layout
+	// MELSECコミュニケーションプロトコル リファレンス(p67) MELSEC-Q/L: 3[byte], MELSEC iQ-R: 4[byte]
+	offsetBuff := new(bytes.Buffer)
+	_ = binary.Write(offsetBuff, binary.LittleEndian, offset)
+	offsetHex := fmt.Sprintf("%X", offsetBuff.Bytes()[0:3]) // 仮にQシリーズとするので3byte trim
+
+	// read points
+	pointsBuff := new(bytes.Buffer)
+	_ = binary.Write(pointsBuff, binary.LittleEndian, numPoints)
+	points := fmt.Sprintf("%X", pointsBuff.Bytes()[0:2]) // 2byte固定
+
+	// data length
+	requestCharLen := len(MONITORING_TIMER+READ_COMMAND+READ_SUB_COMMAND+deviceCode+offsetHex+points) / 2 // 1byte=2char
+	dataLenBuff := new(bytes.Buffer)
+	_ = binary.Write(dataLenBuff, binary.LittleEndian, int64(requestCharLen))
+	dataLen := fmt.Sprintf("%X", dataLenBuff.Bytes()[0:2]) // 2byte固定
+
+	return SUB_HEADER +
+		h.networkNum +
+		h.pcNum +
+		h.unitIONum +
+		h.unitStationNum +
+		dataLen +
+		MONITORING_TIMER +
+		READ_COMMAND +
+		BIT_READ_SUB_COMMAND +
 		offsetHex +
 		deviceCode +
 		points

--- a/mcp/station.go
+++ b/mcp/station.go
@@ -14,7 +14,7 @@ const (
 
 	READ_COMMAND         = "0104" // binary mode expression. if ascii mode then 0401
 	READ_SUB_COMMAND     = "0000"
-	BIT_READ_SUB_COMMAND = "0001"
+	BIT_READ_SUB_COMMAND = "0100"
 
 	WRITE_COMMAND     = "0114" // binary mode expression. if ascii mode then 1401
 	WRITE_SUB_COMMAND = "0000"
@@ -150,7 +150,7 @@ func (h *station) BuildBitReadRequest(deviceName string, offset, numPoints int64
 	points := fmt.Sprintf("%X", pointsBuff.Bytes()[0:2]) // 2byte固定
 
 	// data length
-	requestCharLen := len(MONITORING_TIMER+READ_COMMAND+READ_SUB_COMMAND+deviceCode+offsetHex+points) / 2 // 1byte=2char
+	requestCharLen := len(MONITORING_TIMER+READ_COMMAND+BIT_READ_SUB_COMMAND+deviceCode+offsetHex+points) / 2 // 1byte=2char
 	dataLenBuff := new(bytes.Buffer)
 	_ = binary.Write(dataLenBuff, binary.LittleEndian, int64(requestCharLen))
 	dataLen := fmt.Sprintf("%X", dataLenBuff.Bytes()[0:2]) // 2byte固定


### PR DESCRIPTION
implement bit read command

読み取り命令(1401)のSUB COMMABDを0000から0001に変えることでビット単位での読み取りを行うことができる

実機テスト済

```
B00, numpoint1, bit>
[208 0 0 255 255 3 0 3 0 0 0 16]`
B00, numpoint1, word>
[208 0 0 255 255 3 0 4 0 0 0 1 0]`
B00, numpoint2, bit>
[208 0 0 255 255 3 0 3 0 0 0 16]`
B00, numpoint2, word>
[208 0 0 255 255 3 0 6 0 0 0 1 0 0 0]`
B00, numpoint3, bit>
[208 0 0 255 255 3 0 4 0 0 0 16 0]`
B00, numpoint3, word>
[208 0 0 255 255 3 0 8 0 0 0 1 0 0 0 0 0]`
B00, numpoint4, bit>
[208 0 0 255 255 3 0 4 0 0 0 16 0]`
B00, numpoint4, word>
[208 0 0 255 255 3 0 10 0 0 0 1 0 0 0 0 0 0 0]`
```

bitで読み取った値(00, 01, 10, 11)のいずれかが16進数にエンコードされた状態で返却されました